### PR TITLE
Fix: Prevent .map errors on undefined arrays across all pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001687",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
-      "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
+      "version": "1.0.30001721",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
+      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
       "dev": true,
       "funding": [
         {
@@ -3509,8 +3509,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/src/pages/AllUsersPage.jsx
+++ b/src/pages/AllUsersPage.jsx
@@ -124,7 +124,7 @@ const AllUsersPage = () => {
                   </TableCell>
                 </TableRow>
               ) : users.length > 0 ? (
-                users.map(user => (
+                users.map || [] (user => (
                   <TableRow key={user.id}>
                     <TableCell className="font-medium">{user.name}</TableCell>
                     <TableCell>{user.email}</TableCell>
@@ -139,7 +139,7 @@ const AllUsersPage = () => {
                       </span>
                     </TableCell>
                     <TableCell>
-                      {user.user_roles.map(role => (
+                      {(user.user_roles.map || [] )(role => (
                         <span
                           key={role.title}
                           className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800 mr-1">

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -165,7 +165,7 @@ const ProfilePage = () => {
                 <h1 className="text-2xl font-bold text-gray-900">{user.name}</h1>
                 <p className="text-sm text-gray-500">
                   <div className="space-y-1">
-                    {user.user_roles.map(role => (
+                    {(user.user_roles || []).map(role => (
                       <span
                         key={role.id}
                         className="inline-block px-2 py-1 text-xs font-medium bg-primary-50 
@@ -190,7 +190,7 @@ const ProfilePage = () => {
                 label="Roles"
                 value={
                   <div className="space-y-1">
-                    {user?.designation.map(role => (
+                    {(user?.designation|| []).map(role => (
                       <span
                         key={role.id}
                         className="inline-block px-2 py-1 text-xs font-medium bg-primary-50 

--- a/src/pages/entity-types/EntityTypesTable.jsx
+++ b/src/pages/entity-types/EntityTypesTable.jsx
@@ -70,7 +70,7 @@ export const EntityTypesTable = ({ entityTypes, onUpdateEntityTypes, onInheritSu
                 <TableCell>{type.label}</TableCell>
                 <TableCell>{type.value}</TableCell>
                 <TableCell>
-                  {type.model_names.map(modelName => (
+                  {(type.model_names || []).map(modelName => (
                     <span
                       key={modelName}
                       className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800 mr-1">


### PR DESCRIPTION
This PR updates all relevant components to safely handle cases where array properties (such as model_names, user_roles, designation, etc.) may be undefined or null. By providing a fallback to an empty array before calling .map, this change prevents runtime errors and white screens throughout the application. This improves overall stability and user experience, especially when backend data is incomplete or missing expected fields.

Before:
![image](https://github.com/user-attachments/assets/c78beced-d454-4b4f-a636-c2ae9243213e)

What I added:
![image](https://github.com/user-attachments/assets/6e823d97-3df9-4982-80e6-5df5fe1ce9a2)

After:
![image](https://github.com/user-attachments/assets/a8f50732-b943-4309-9f32-423fe3c6e9c2)

Same with other pages

